### PR TITLE
Uses Umami to send analytics instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@google/generative-ai": "^0.22.0",
-    "@vercel/analytics": "^1.4.1",
     "next": "15.1.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import {Analytics} from "@vercel/analytics/next";
 import Footer from './components/Footer';
 import Navigation from "./components/Navigation";
 import { ThemeProvider } from './components/ThemeProvider'
@@ -95,6 +94,9 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">
+      <head>
+        <script defer src="https://cloud.umami.is/script.js" data-website-id="96fc4b45-d8c8-4941-8a4f-330723725623"></script>
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100 transition-colors duration-300 min-h-screen flex flex-col`}
       >
@@ -104,7 +106,6 @@ export default function RootLayout({
             {children}
           </main>
           <Footer />
-          <Analytics />
         </ThemeProvider>
       </body>
     </html>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -23,7 +23,7 @@ export default function Privacy() {
         <section className="mb-8">
           <h2 className="text-2xl font-semibold mb-4">Analytics</h2>
           <p>
-            We use Vercel Analytics to collect anonymous usage statistics. This helps us understand how 
+            We use Umami Analytics to collect anonymous usage statistics. This helps us understand how 
             the tool is being used and improve it. The analytics data collected includes:
           </p>
           <ul className="list-disc pl-6 mb-4">
@@ -34,6 +34,9 @@ export default function Privacy() {
           <p>
             No personally identifiable information is collected through analytics.
           </p>
+          <p>
+            We own our own analytics data and do not sell it to third parties.
+          </p>
         </section>
 
         <section className="mb-8">
@@ -42,7 +45,7 @@ export default function Privacy() {
             We use the following third-party services:
           </p>
           <ul className="list-disc pl-6 mb-4">
-            <li>Vercel - For hosting and analytics</li>
+            <li>Umami - For privacy-focused analytics</li>
             <li>Google AI - For resume processing (no data retention)</li>
           </ul>
         </section>

--- a/src/app/services/analytics.ts
+++ b/src/app/services/analytics.ts
@@ -1,3 +1,10 @@
+// Type declaration for Umami
+declare global {
+  interface Window {
+    umami?: (eventName: string, eventData?: Record<string, unknown>) => void;
+  }
+}
+
 // Analytics event types
 export type AnalyticsEvent = {
   name: string;
@@ -12,15 +19,12 @@ export const analytics = {
       return;
     }
 
-    // Send to Vercel Analytics with better error handling
+    // Send to Umami Analytics
     try {
-      if (typeof window !== 'undefined' && window.va && typeof window.va === 'object') {
-        const va = window.va as { track: (name: string, properties?: Record<string, unknown>) => void };
-        if (typeof va.track === 'function') {
-          va.track(event.name, event.properties);
-        } else {
-          console.warn('Vercel Analytics track method not available');
-        }
+      if (typeof window !== 'undefined' && window.umami && typeof window.umami === 'function') {
+        window.umami(event.name, event.properties);
+      } else {
+        console.warn('Umami Analytics not available');
       }
     } catch (error) {
       console.warn('Error tracking analytics event:', error);


### PR DESCRIPTION
## 🤖 AI Summary
  - **Removed Vercel Analytics:** The `@vercel/analytics` dependency and its usage throughout the application have been removed.
- **Added Umami Analytics:**  Umami analytics has been implemented using a direct script include in the `<head>` and updated throughout the codebase.  The privacy policy has been updated to reflect this change, highlighting Umami's privacy-focused nature.  `src/app/services/analytics.ts` has been modified to track events using Umami's API.

  <sub>🕒 Generated at Mon Mar  3 19:57:07 UTC 2025</sub>