### PR TITLE
Adds newer models being used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "resume-tailor",
       "version": "0.1.0",
       "dependencies": {
-        "@google/generative-ai": "^0.22.0",
+        "@google/generative-ai": "^0.24.0",
         "@types/mailgun-js": "^0.22.18",
         "@umami/api-client": "^0.77.0",
         "@vercel/analytics": "^1.4.1",
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@google/generative-ai": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.22.0.tgz",
-      "integrity": "sha512-mLR3PDWCk5O/BWNyDvFDIiwKeXQmFGZ+kJFd9m73QrUPCFREttJyVbBPTW4y9CwTbaltLMDaLDfroCrRv5Bl8Q==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.0.tgz",
+      "integrity": "sha512-fnEITCGEB7NdX0BhoYZ/cq/7WPZ1QS5IzJJfC3Tg/OwkvBetMiVJciyaan297OvE4B9Jg1xvo0zIazX/9sGu1Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@google/generative-ai": "^0.22.0",
+    "@google/generative-ai": "^0.24.0",
     "@types/mailgun-js": "^0.22.18",
     "@umami/api-client": "^0.77.0",
     "@vercel/analytics": "^1.4.1",

--- a/src/app/api/relevancy/route.ts
+++ b/src/app/api/relevancy/route.ts
@@ -7,7 +7,7 @@ if (!process.env.GEMINI_API_KEY) {
 
 // Initialize the Google AI client
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
-const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+const model = genAI.getGenerativeModel({ model: "gemini-2.0-flash-lite" });
 
 async function evaluateResumeRelevancy(resume: string, jobDescription: string): Promise<number> {
   try {

--- a/src/app/api/tailor/job/title/route.ts
+++ b/src/app/api/tailor/job/title/route.ts
@@ -12,7 +12,7 @@ async function getModel() {
   }
   
   const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-  return genAI.getGenerativeModel({ model: "gemini-1.5-flash-8b" });
+  return genAI.getGenerativeModel({ model: "gemini-2.0-flash-lite" });
 }
 
 export async function POST(req: NextRequest) {

--- a/src/app/api/tailor/route.ts
+++ b/src/app/api/tailor/route.ts
@@ -8,7 +8,7 @@ if (!process.env.GEMINI_API_KEY) {
 
 // Initialize the Google AI client
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY!);
-const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+const model = genAI.getGenerativeModel({ model: "gemini-2.0-flash" });
 
 // Cooldown period in milliseconds (e.g., 1 minute = 60000ms)
 const COOLDOWN_PERIOD = 60000;


### PR DESCRIPTION
## 🤖 AI Summary
  Updated `@google/generative-ai` dependency from `^0.22.0` to `^0.24.0` and switched the Google Gemini AI model used in several API routes (`/api/relevancy`, `/api/tailor`, `/api/tailor/job/title`) from `gemini-1.5-flash` or `gemini-1.5-flash-8b` to `gemini-2.0-flash` or `gemini-2.0-flash-lite`.

  <sub>🕒 Generated at Mon Mar 31 18:18:59 UTC 2025</sub>