### PR TITLE
Improve anti-AI resume authenticity and post-processing quality scoring

### DIFF
--- a/src/app/utils/qualityAssurance.ts
+++ b/src/app/utils/qualityAssurance.ts
@@ -12,6 +12,13 @@ export interface QualityMetrics {
   overallScore: number; // 0-100
 }
 
+export interface AuthenticityMetrics {
+  aiSmellScore: number; // 0-100 (lower is better)
+  polishedPhraseHits: number;
+  repetitiveBulletStarts: number;
+  firstPersonPronounHits: number;
+}
+
 const COMMON_CLICHÉS = [
   'results-driven',
   'detail-oriented',
@@ -33,6 +40,30 @@ const COMMON_CLICHÉS = [
   'committed',
   'expertise in',
   'extensive experience'
+];
+
+const AI_SMELL_PATTERNS: RegExp[] = [
+  /culture-focused approach/gi,
+  /security-first design patterns?/gi,
+  /ai-enhanced (solutions|data processing)/gi,
+  /leveraging\s+.+?\s+to\s+drive/gi,
+  /applying\s+.+?\s+to\s+enhance/gi,
+  /best practices/gi,
+  /cutting-edge/gi,
+  /industry standard/gi,
+];
+
+const PHRASE_REPLACEMENTS: Array<[RegExp, string]> = [
+  [/\butilize\b/gi, 'use'],
+  [/\bleverage\b/gi, 'use'],
+  [/\bsynergy\b/gi, 'collaboration'],
+  [/\bresults-driven\b/gi, 'outcome-focused'],
+  [/\bdetail-oriented\b/gi, 'precise'],
+  [/\bproven track record\b/gi, 'track record'],
+  [/\bpassionate about\b/gi, 'focused on'],
+  [/\bteam player\b/gi, 'collaborative contributor'],
+  [/\bbest practices\b/gi, 'production standards'],
+  [/\bcutting-edge\b/gi, 'modern'],
 ];
 
 /**
@@ -125,6 +156,60 @@ export function validateQuality(
 }
 
 /**
+ * Deterministically rewrite common AI-sounding phrasing while preserving resume meaning.
+ */
+export function normalizeAIPhrasing(text: string): { text: string; replacements: number } {
+  let normalized = text;
+  let replacements = 0;
+
+  for (const [pattern, replacement] of PHRASE_REPLACEMENTS) {
+    const matches = normalized.match(pattern);
+    if (matches) {
+      replacements += matches.length;
+      normalized = normalized.replace(pattern, replacement);
+    }
+  }
+
+  return { text: normalized, replacements };
+}
+
+/**
+ * Measures whether resume output sounds machine-generated.
+ */
+export function measureAuthenticity(text: string): AuthenticityMetrics {
+  let polishedPhraseHits = 0;
+  for (const pattern of AI_SMELL_PATTERNS) {
+    polishedPhraseHits += text.match(pattern)?.length ?? 0;
+  }
+
+  const bulletStarts = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => /^[-*•]\s+/.test(line))
+    .map((line) => line.replace(/^[-*•]\s+/, '').split(/\s+/)[0]?.toLowerCase())
+    .filter(Boolean);
+
+  const bulletStartCounts = new Map<string, number>();
+  for (const start of bulletStarts) {
+    bulletStartCounts.set(start, (bulletStartCounts.get(start) ?? 0) + 1);
+  }
+  const repetitiveBulletStarts = Array.from(bulletStartCounts.values()).filter((count) => count >= 3).length;
+  const firstPersonPronounHits = text.match(/\b(i|my|me|mine)\b/gi)?.length ?? 0;
+
+  const aiSmellScore = Math.min(
+    100,
+    polishedPhraseHits * 18 + repetitiveBulletStarts * 14 + firstPersonPronounHits * 6
+  );
+
+  return {
+    aiSmellScore,
+    polishedPhraseHits,
+    repetitiveBulletStarts,
+    firstPersonPronounHits,
+  };
+}
+
+/**
  * Get quality recommendations based on metrics
  */
 export function getQualityRecommendations(metrics: QualityMetrics): string[] {
@@ -148,7 +233,6 @@ export function getQualityRecommendations(metrics: QualityMetrics): string[] {
   
   return recommendations;
 }
-
 
 
 

--- a/tests/unit/utils/qualityAssurance.test.ts
+++ b/tests/unit/utils/qualityAssurance.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateQuality,
+  normalizeAIPhrasing,
+  measureAuthenticity,
+} from '@/app/utils/qualityAssurance';
+
+describe('qualityAssurance utilities', () => {
+  it('normalizes common AI-sounding phrases', () => {
+    const input = 'Results-driven engineer who can leverage best practices and utilize modern tooling.';
+    const output = normalizeAIPhrasing(input);
+
+    expect(output.text).toContain('outcome-focused');
+    expect(output.text).toContain('use production standards');
+    expect(output.replacements).toBeGreaterThan(0);
+  });
+
+  it('measures authenticity signals', () => {
+    const text = `
+- Developed APIs for billing and search
+- Developed dashboards for product analytics
+- Developed CI workflows for deployment
+I improved release quality with team support.
+`;
+
+    const metrics = measureAuthenticity(text);
+
+    expect(metrics.repetitiveBulletStarts).toBeGreaterThan(0);
+    expect(metrics.firstPersonPronounHits).toBeGreaterThan(0);
+    expect(metrics.aiSmellScore).toBeGreaterThan(0);
+  });
+
+  it('keeps quality score healthy for quantified concrete text', () => {
+    const original = 'Built internal systems.';
+    const improved = 'Built internal systems that reduced support tickets by 22% across 3 quarters.';
+
+    const metrics = validateQuality(original, improved);
+
+    expect(metrics.hasMetrics).toBe(true);
+    expect(metrics.overallScore).toBeGreaterThan(50);
+  });
+});


### PR DESCRIPTION
### Motivation
- Reduce machine-generated "AI smell" in tailored resumes so outputs read more human and compete better with products like TealHQ.
- Provide deterministic post-processing and measurable telemetry so authenticity improvements are repeatable and tunable.
- Preserve ATS/keyword optimizations while removing templated phrasing and repetitive patterns that trigger AI-detection.

### Description
- Added deterministic anti-AI utilities in `src/app/utils/qualityAssurance.ts`: `normalizeAIPhrasing`, `measureAuthenticity`, `AuthenticityMetrics`, AI-smell patterns, and phrase replacement rules. 
- Integrated normalization and authenticity measurement into the tailoring stream at `src/app/api/humanize/stream/route.ts` so the tailored resume is sanitized, deduplicated, normalized, and scored before being returned. 
- Enriched the stream completion payload with `improvementMetrics.qualityScore` (derived from authenticity score) and a `qualityMetrics` object that includes `antiAiReplacements` and detailed authenticity diagnostics. 
- Added unit tests `tests/unit/utils/qualityAssurance.test.ts` covering normalization, authenticity metrics, and quality scoring, and updated prompt tests to ensure prompt content expectations remain satisfied.

### Testing
- Ran unit tests with `vitest run --run tests/unit/utils/qualityAssurance.test.ts tests/unit/prompts/tailoring.test.ts`, and all tests passed. 
- Added and ran targeted unit tests for the new utilities and they succeeded. 
- Ran `npm run lint` which failed in this environment due to a project lint script/path issue (`Invalid project directory provided, no such directory: /workspace/resume-tailor/lint`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997fed5dc2c8333b8c2bde0792bc55b)